### PR TITLE
sepolicy: public: add TCSETSF to the list of unprivileged TTY ioctls

### DIFF
--- a/public/ioctl_macros
+++ b/public/ioctl_macros
@@ -49,7 +49,7 @@ define(`unpriv_unix_sock_ioctls', `{
 # commonly used TTY ioctls
 # merge with unpriv_unix_sock_ioctls?
 define(`unpriv_tty_ioctls', `{
-  TIOCOUTQ FIOCLEX TCGETS TCSETS TIOCGWINSZ TIOCSWINSZ TIOCSCTTY TCSETSW
+  TIOCOUTQ FIOCLEX TCGETS TCSETS TCSETSF TIOCGWINSZ TIOCSWINSZ TIOCSCTTY TCSETSW
   TCFLSH TIOCSPGRP TIOCGPGRP
 }')
 


### PR DESCRIPTION
* This allows interactive "su" sessions started from a terminal app
  (therefore running in untrusted_app context) to fully interact with
  their respective untrusted_app_devpts.
* This fixes "su" behavior such as broken tab completion, or
  Ctrl-C exiting the su shell.
* Denial:

  avc: denied { ioctl } for pid=5629 comm="su" path="/dev/pts/2" dev="devpts"
  ino=5 ioctlcmd=5404 scontext=u:r:untrusted_app:s0:c512,c768
  tcontext=u:object_r:untrusted_app_devpts:s0:c512,c768
  tclass=chr_file permissive=0

Change-Id: Ic0867a40ed29348abb03bb91df4c5807379f9df0
Signed-off-by: Vladimir Oltean <olteanv@gmail.com>